### PR TITLE
Fix mem_map_find_region() bug.

### DIFF
--- a/src/mem_map.c
+++ b/src/mem_map.c
@@ -601,6 +601,7 @@ static struct mem_region *mem_map_find_region(struct mem_map *map, void *addr)
         fprintf(stderr,
                 "cannot find region of memory containing 0x%lx\nmap:\n",
                 (size_t)addr);
+        region = NULL;
     } else {
         region = *region_ptr;
         map->prev_accessed_region = region;


### PR DESCRIPTION
In the case mem_map_find_region() cannot find a region, it was returning
the previous value assigned to region, which was map->previous_accessed_region,
but it should be returning NULL.
