### PR TITLE
Print thread name when dumping backtrace

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -103,15 +103,15 @@ int backtrace_snapshot(int pid, int *tids, int *index, int nr_tids)
 {
     int i, rc = 0;
     struct snapshot *snap;
-    
+
     if ((snap = get_snapshot(pid, tids, index, nr_tids)) == NULL)
         return -1;
 
     for (i = 0; i < snap->num_threads; ++i) {
-        printf("--------------------  thread %d (%d) (",
-               (index != NULL ? index[i] : i+1), snap->tids[i]);
-        print_proc_comm(snap->tids[i]);
-        printf(")  --------------------\n");
+        char comm[16];
+
+        get_thread_comm(snap->tids[i], comm, sizeof(comm));
+        printf("--------------------  thread %d (%d) (%s)  --------------------\n", (index != NULL ? index[i] : i+1), snap->tids[i], comm);
 
         snap->cur_thr = i;
         if (backtrace_thread(&snapshot_addr_space_accessors, snap) < 0)
@@ -146,11 +146,11 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
 
     for (i = 0; i < count; ++i) {
         void *upt_info;
+        char comm[16];
 
-        printf("--------------------  thread %d (%d) (",
-               (index != NULL ? index[i] : i+1), threads[i]);
-        print_proc_comm(threads[i]);
-        printf(")  --------------------\n");
+        get_thread_comm(threads[i], comm, sizeof(comm));
+
+        printf("--------------------  thread %d (%d) (%s)  --------------------\n",(index != NULL ? index[i] : i+1), threads[i], comm);
 
         if (threads[i] != pid && attach_thread(threads[i]) < 0) {
             rc = -1;

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -108,8 +108,10 @@ int backtrace_snapshot(int pid, int *tids, int *index, int nr_tids)
         return -1;
 
     for (i = 0; i < snap->num_threads; ++i) {
-        printf("--------------------  thread %d (%d)  --------------------\n",
+        printf("--------------------  thread %d (%d) (",
                (index != NULL ? index[i] : i+1), snap->tids[i]);
+        print_proc_comm(snap->tids[i]);
+        printf(")  --------------------\n");
 
         snap->cur_thr = i;
         if (backtrace_thread(&snapshot_addr_space_accessors, snap) < 0)
@@ -145,8 +147,10 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
     for (i = 0; i < count; ++i) {
         void *upt_info;
 
-        printf("--------------------  thread %d (%d)  --------------------\n",
+        printf("--------------------  thread %d (%d) (",
                (index != NULL ? index[i] : i+1), threads[i]);
+        print_proc_comm(threads[i]);
+        printf(")  --------------------\n");
 
         if (threads[i] != pid && attach_thread(threads[i]) < 0) {
             rc = -1;

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -108,10 +108,16 @@ int backtrace_snapshot(int pid, int *tids, int *index, int nr_tids)
         return -1;
 
     for (i = 0; i < snap->num_threads; ++i) {
+        int x;
         char comm[16];
+        char end_pad[25] = "------------------------";
 
-        get_thread_comm(snap->tids[i], comm, sizeof(comm));
-        printf("--------------------  thread %d (%d) (%s)  --------------------\n", (index != NULL ? index[i] : i+1), snap->tids[i], comm);
+        x = get_thread_comm(snap->tids[i], comm, sizeof(comm));
+        if (x > 0 && x <= sizeof(end_pad))
+        {
+            end_pad[sizeof(end_pad) - x] = '\0';
+            printf("-------------- thread %d (%d) (%s) %s\n", (index != NULL ? index[i] : i+1), snap->tids[i], comm, end_pad);
+        }
 
         snap->cur_thr = i;
         if (backtrace_thread(&snapshot_addr_space_accessors, snap) < 0)
@@ -146,11 +152,17 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
 
     for (i = 0; i < count; ++i) {
         void *upt_info;
+        int x;
         char comm[16];
+        char end_pad[25] = "------------------------";
 
-        get_thread_comm(threads[i], comm, sizeof(comm));
+        x = get_thread_comm(threads[i], comm, sizeof(comm));
 
-        printf("--------------------  thread %d (%d) (%s)  --------------------\n",(index != NULL ? index[i] : i+1), threads[i], comm);
+        if (x > 0 && x <= sizeof(end_pad))
+        {
+            end_pad[sizeof(end_pad) - x] = '\0';
+            printf("-------------- thread %d (%d) (%s) %s\n", (index != NULL ? index[i] : i + 1), threads[i], comm, end_pad);
+        }
 
         if (threads[i] != pid && attach_thread(threads[i]) < 0) {
             rc = -1;

--- a/src/proc.c
+++ b/src/proc.c
@@ -191,6 +191,30 @@ int print_proc_maps(int pid)
     return system(cmd);
 }
 
+int print_proc_comm(int pid)
+{
+    FILE *f;
+    char buf[32] = "";
+    int i;
+    int rc = -1;
+
+    snprintf(buf, sizeof(buf), "/proc/%d/comm", pid);
+    if ((f = fopen(buf, "r")) == NULL) {
+        fprintf(stderr, "cannot open %s: %s\n", buf, strerror(errno));
+        return -1;
+    }
+
+    if (fgets(buf, sizeof(buf), f)) {
+        i = strcspn(buf, "\n");
+        buf[i] = '\0';
+        printf("%s", buf);
+        rc = 0;
+    }
+
+    fclose(f);
+    return rc;
+}
+
 /*
  * filter for scandir(). choose only thread identifiers
  */

--- a/src/proc.c
+++ b/src/proc.c
@@ -215,9 +215,9 @@ int get_thread_comm(int pid, char * dst, size_t n)
     if (fgets(buf, sizeof(buf), f)) {
         i = strcspn(buf, "\n");
         buf[i] = '\0';
-        x = MAX(MIN(n-1, i+1), 0);
+        x = MAX(MIN(n, i+1), 1);
         strncpy(dst, buf, x);
-        dst[x] = '\0';
+        dst[x-1] = '\0';
         rc = x;
     }
 

--- a/src/proc.c
+++ b/src/proc.c
@@ -34,6 +34,9 @@
 
 #define SLEEP_WAIT 500
 
+#define MAX(a,b) ((a) > (b) ? a : b)
+#define MIN(a,b) ((a) < (b) ? a : b)
+
 int attached_pid = 0;
 
 /* timeout on waiting for process to stop (us) */
@@ -191,12 +194,17 @@ int print_proc_maps(int pid)
     return system(cmd);
 }
 
-int print_proc_comm(int pid)
+int get_thread_comm(int pid, char * dst, size_t n)
 {
     FILE *f;
-    char buf[32] = "";
-    int i;
+    char buf[32];
+    int i, x;
     int rc = -1;
+
+    if (dst == NULL)
+    {
+        return -1;
+    }
 
     snprintf(buf, sizeof(buf), "/proc/%d/comm", pid);
     if ((f = fopen(buf, "r")) == NULL) {
@@ -207,8 +215,10 @@ int print_proc_comm(int pid)
     if (fgets(buf, sizeof(buf), f)) {
         i = strcspn(buf, "\n");
         buf[i] = '\0';
-        printf("%s", buf);
-        rc = 0;
+        x = MAX(MIN(n-1, i+1), 0);
+        strncpy(dst, buf, x);
+        dst[x] = '\0';
+        rc = x;
     }
 
     fclose(f);

--- a/src/proc.h
+++ b/src/proc.h
@@ -28,10 +28,9 @@ struct mem_map *create_maps(int pid);
 int print_proc_maps(int pid);
 
 /*
- * simple routine to print process comm for
- * debugging or advanced error reporting
+ * copy pid process comm into dst string, up to n characters
  */
-int print_proc_comm(int pid);
+int get_thread_comm(int pid, char * dst, size_t n);
 
 /*
  * get thread identifiers of the process

--- a/src/proc.h
+++ b/src/proc.h
@@ -28,6 +28,12 @@ struct mem_map *create_maps(int pid);
 int print_proc_maps(int pid);
 
 /*
+ * simple routine to print process comm for
+ * debugging or advanced error reporting
+ */
+int print_proc_comm(int pid);
+
+/*
  * get thread identifiers of the process
  */
 int get_threads(int pid, int **tids);


### PR DESCRIPTION
Keeping proc interactions isoltated: added function in proc.h/.c
that prints thread name to stdout. It is then used by backtrace.c
directly to keep from having to store the string in memory in
snapshot or any other struct
