### PR TITLE
Fix implicit declaration warning

### DIFF
--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -6,6 +6,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
 #include <libelf.h>


### PR DESCRIPTION
The warning was:
```
src/tbstack.c: In function ‘parse_pid_arg’:
src/tbstack.c:101:25: warning: implicit declaration of function ‘isdigit’ [-Wimplicit-function-declaration]
             } else if (!isdigit(c)) {
                         ^~~~~~~
```