### PR TITLE
Always try to use process_vm_readv first

### DIFF
--- a/README
+++ b/README
@@ -45,9 +45,8 @@ usage:    tbstack <pid>
 options:  --help                show this
           --ignore-deleted      try to open shared objects marked as deleted
           --use-waitpid-timeout set alarm to interrupt waitpid
-          --proc-mem            prefer reading /proc/pid/mem (default on systems
-                                with kernel older than 3.2. on modern kernels
-                                default flavor is process_vm_readv)
+          --proc-mem            prefer reading /proc/pid/mem. default flavor
+                                is process_vm_readv
           --ptrace              use libunwind-ptrace interface (slower)
           --show-rsp            show %rsp in second column
           --stack-size <size>   maximum stack size to copy (default is current
@@ -76,8 +75,8 @@ it examines process' memory layout reading /proc/pid/maps. When the process is
 frozen (PTRACE_ATTACH to the main thread + SIGSTOP to start freezing other
 threads) it copies all threads' general-purpose registers and contents of stack
 from %rsp to end of memory region or up to maximum stack size if specified
-with --stack-size argument. System call proc_vm_readv is used on kernels from
-version 3.2, on older kernels data is read from /proc/pid/mem. The process
+with --stack-size argument. System call proc_vm_readv is used. If it is not
+supported, the program falls back to reading /proc/pid/mem. The process
 continues execution. The collected data is enough to trace stacks. It is
 arranged in structures snapshot and mem_map and can be accessed through callback
 routines passed to libunwind by unw_create_addr_space (see

--- a/src/proc.h
+++ b/src/proc.h
@@ -66,17 +66,9 @@ int detach_thread(int tid);
 int wait_thread(int tid);
 
 /*
- * copy memory contents using process_vm_readv(). reduces number
- * of system calls comparing to /proc/mem
+ * copy process' memory contents
  */
-int copy_memory_process_vm_readv(int pid,
-        struct mem_data_chunk **frames, int n_frames);
-
-/*
- * read the file /proc/<pid>/mem on older kernels
- */
-int copy_memory_proc_mem(int pid,
-        struct mem_data_chunk **frames, int n_frames);
+int copy_memory(int pid, struct mem_data_chunk **frames, int n_frames);
 
 /*
  * resolve VDSO mapping address

--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -50,9 +50,8 @@ static int usage(const char *name)
 "options:  --help                show this\n"
 "          --ignore-deleted      try to open shared objects marked as deleted\n"
 "          --use-waitpid-timeout set alarm to interrupt waitpid\n"
-"          --proc-mem            prefer reading /proc/pid/mem (default on systems\n"
-"                                with kernel older than 3.2. on modern kernels\n"
-"                                default flavor is process_vm_readv)\n"
+"          --proc-mem            prefer reading /proc/pid/mem. default flavor\n"
+"                                is process_vm_readv\n"
 #if !defined (NO_LIBUNWIND_PTRACE)
 "          --ptrace              use libunwind-ptrace interface (slower)\n"
 #endif


### PR DESCRIPTION
Kernel version is not a good indicator of having process_vm_readv available. It can be backported in older kernels, yet it can be disabled in kernel configuration.

Kernel version check has been removed. The new default behavior is to call process_vm_readv and fall back to reading /proc/pid/mem on ENOSYS. The behavior with --proc-mem specified didn't change.