### PR TITLE
Thread states

### DIFF
--- a/README
+++ b/README
@@ -50,6 +50,7 @@ options:  --help                show this
                                 is process_vm_readv
           --ptrace              use libunwind-ptrace interface (slower)
           --show-rsp            show %rsp in second column
+          --show-state          show thread state before freeze
           --stack-size <size>   maximum stack size to copy (default is current
                                 RLIMIT_STACK)
           --stop-timeout        timeout for waiting the process to freeze, in

--- a/README
+++ b/README
@@ -50,7 +50,7 @@ options:  --help                show this
                                 is process_vm_readv
           --ptrace              use libunwind-ptrace interface (slower)
           --show-rsp            show %rsp in second column
-          --show-state          show thread state before freeze
+          --show-state          show thread states
           --stack-size <size>   maximum stack size to copy (default is current
                                 RLIMIT_STACK)
           --stop-timeout        timeout for waiting the process to freeze, in

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -102,7 +102,7 @@ static int backtrace_thread(unw_accessors_t *accessors, void *arg)
 }
 
 void print_thread_heading(const int *index, const int *tids,
-        const char *states, int i)
+        const char states[], int i)
 {
     int ind = (index != NULL ? index[i] : i+1);
     if (opt_show_state) {

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -5,6 +5,7 @@
  * All rights reserved.
  */
 
+#include <assert.h>
 #include <libunwind.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,6 +22,7 @@
 extern unw_accessors_t snapshot_addr_space_accessors;
 
 extern int opt_show_rsp;
+extern int opt_show_state;
 extern int opt_verbose;
 
 static int backtrace_thread(unw_accessors_t *accessors, void *arg)
@@ -99,6 +101,21 @@ static int backtrace_thread(unw_accessors_t *accessors, void *arg)
     return rc;
 }
 
+void print_thread_heading(const int *index, const int *tids,
+        const char *states, int i)
+{
+    int ind = (index != NULL ? index[i] : i+1);
+    if (opt_show_state) {
+        assert(states != NULL);
+        printf("--------------------  thread %d (%d) (%c) "
+               "--------------------\n",
+               ind, tids[i], states[i]);
+    } else {
+        printf("--------------------  thread %d (%d)  --------------------\n",
+               ind, tids[i]);
+    }
+}
+
 int backtrace_snapshot(int pid, int *tids, int *index, int nr_tids)
 {
     int i, rc = 0;
@@ -108,8 +125,7 @@ int backtrace_snapshot(int pid, int *tids, int *index, int nr_tids)
         return -1;
 
     for (i = 0; i < snap->num_threads; ++i) {
-        printf("--------------------  thread %d (%d)  --------------------\n",
-               (index != NULL ? index[i] : i+1), snap->tids[i]);
+        print_thread_heading(index, snap->tids, snap->states, i);
 
         snap->cur_thr = i;
         if (backtrace_thread(&snapshot_addr_space_accessors, snap) < 0)
@@ -125,6 +141,7 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
 #if !defined (NO_LIBUNWIND_PTRACE)
     int i, count, rc = 0;
     int *threads = NULL;
+    char *states = NULL;
 
     count = get_threads(pid, &threads);
     if (!count || threads == NULL)
@@ -139,14 +156,16 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
         threads = tids;
     }
 
+    if (opt_show_state)
+        states = get_thread_states(threads, count);
+
     if (attach_process(pid) < 0)
         return -1;
 
     for (i = 0; i < count; ++i) {
         void *upt_info;
 
-        printf("--------------------  thread %d (%d)  --------------------\n",
-               (index != NULL ? index[i] : i+1), threads[i]);
+        print_thread_heading(index, threads, states, i);
 
         if (threads[i] != pid && attach_thread(threads[i]) < 0) {
             rc = -1;
@@ -170,6 +189,8 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
 
     if (detach_process(pid) < 0)
         return -1;
+
+    free(states);
 
     return rc;
 

--- a/src/proc.c
+++ b/src/proc.c
@@ -51,11 +51,12 @@ extern int opt_proc_mem;
 extern int opt_use_waitpid_timeout;
 extern int opt_verbose;
 
-char proc_state(int pid)
+int proc_state(int pid)
 {
     FILE *f;
     char buf[128];
-    char c = -1;
+    char c;
+    int res = -1;
 
     sprintf(buf, "/proc/%d/status", pid);
     if ((f = fopen(buf, "r")) == NULL) {
@@ -64,17 +65,19 @@ char proc_state(int pid)
     }
 
     while (fgets(buf, sizeof(buf), f)) {
-        if (sscanf(buf, "State:\t%c", &c) == 1)
+        if (sscanf(buf, "State:\t%c", &c) == 1) {
+            res = c;
             break;
+        }
     }
 
     fclose(f);
-    return c;
+    return res;
 }
 
 static int proc_stopped(int pid)
 {
-    char c = proc_state(pid);
+    int c = proc_state(pid);
     if (c == -1)
         return -1;
 
@@ -243,7 +246,7 @@ char *get_thread_states(const int *tids, int n)
     char *res = calloc(1, n);
 
     for (i = 0; i < n; ++i) {
-        char state = proc_state(tids[i]);
+        int state = proc_state(tids[i]);
         if (state < 0) {
             fprintf(stderr, "warning: could not get state of thread %d\n",
                     tids[i]);

--- a/src/proc.c
+++ b/src/proc.c
@@ -51,12 +51,11 @@ extern int opt_proc_mem;
 extern int opt_use_waitpid_timeout;
 extern int opt_verbose;
 
-int proc_stopped(int pid)
+char proc_state(int pid)
 {
     FILE *f;
     char buf[128];
-    char c;
-    int rc = -1;
+    char c = -1;
 
     sprintf(buf, "/proc/%d/status", pid);
     if ((f = fopen(buf, "r")) == NULL) {
@@ -65,14 +64,21 @@ int proc_stopped(int pid)
     }
 
     while (fgets(buf, sizeof(buf), f)) {
-        if (sscanf(buf, "State:\t%c", &c) == 1) {
-            rc = (c == 't' || c == 'T');
+        if (sscanf(buf, "State:\t%c", &c) == 1)
             break;
-        }
     }
 
     fclose(f);
-    return rc;
+    return c;
+}
+
+static int proc_stopped(int pid)
+{
+    char c = proc_state(pid);
+    if (c == -1)
+        return -1;
+
+    return (c == 't' || c == 'T');
 }
 
 struct mem_map *create_maps(int pid)
@@ -229,6 +235,24 @@ int get_threads(int pid, int **tids)
     }
 
     return n;
+}
+
+char *get_thread_states(const int *tids, int n)
+{
+    int i;
+    char *res = calloc(1, n);
+
+    for (i = 0; i < n; ++i) {
+        char state = proc_state(tids[i]);
+        if (state < 0) {
+            fprintf(stderr, "warning: could not get state of thread %d\n",
+                    tids[i]);
+            break;
+        }
+        res[i] = state;
+    }
+
+    return res;
 }
 
 int adjust_threads(int *tids, int nr_tids, int *user_tids,

--- a/src/proc.h
+++ b/src/proc.h
@@ -12,9 +12,9 @@ struct mem_data_chunk;
 struct mem_map;
 
 /*
- * get process state (R, S, D, T, ...)
+ * returns process state (R, S, D, T, ...) or -1 on error
  */
-char proc_state(int pid);
+int proc_state(int pid);
 
 /*
  * parse /proc/<pid>/maps file and create mem_map structure

--- a/src/proc.h
+++ b/src/proc.h
@@ -33,7 +33,8 @@ int print_proc_maps(int pid);
 int get_threads(int pid, int **tids);
 
 /*
- * get thread states
+ * returns a pointer to dynamically allocated array of characters representing
+ * thread states as found in /proc/<pid>/status
  */
 char *get_thread_states(const int *tids, int n);
 

--- a/src/proc.h
+++ b/src/proc.h
@@ -12,9 +12,9 @@ struct mem_data_chunk;
 struct mem_map;
 
 /*
- * check if the process is in state stopped (S)
+ * get process state (R, S, D, T, ...)
  */
-int proc_stopped(int pid);
+char proc_state(int pid);
 
 /*
  * parse /proc/<pid>/maps file and create mem_map structure
@@ -31,6 +31,11 @@ int print_proc_maps(int pid);
  * get thread identifiers of the process
  */
 int get_threads(int pid, int **tids);
+
+/*
+ * get thread states
+ */
+char *get_thread_states(const int *tids, int n);
 
 /*
  * translate thread numbers to system lwp ids

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -89,9 +89,6 @@ struct snapshot *get_snapshot(int pid, int *tids, int *index, int nr_tids)
         goto get_snapshot_fail;
     }
 
-    /*
-     * get thread states if requested by user
-     */
     if (opt_show_state)
         res->states = get_thread_states(res->tids, res->num_threads);
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -19,6 +19,7 @@
 #include <elf.h>
 
 extern size_t stack_size;
+extern int opt_show_state;
 extern int opt_verbose;
 
 void snapshot_destroy(struct snapshot *snap)
@@ -31,6 +32,7 @@ void snapshot_destroy(struct snapshot *snap)
 
     free(snap->regs);
     free(snap->tids);
+    free(snap->states);
     free(snap);
 }
 
@@ -86,6 +88,12 @@ struct snapshot *get_snapshot(int pid, int *tids, int *index, int nr_tids)
         perror("malloc");
         goto get_snapshot_fail;
     }
+
+    /*
+     * get thread states if requested by user
+     */
+    if (opt_show_state)
+        res->states = get_thread_states(res->tids, res->num_threads);
 
     /* FREEZE PROCESS */
     if (attach_process(pid) < 0)

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -36,6 +36,8 @@ struct snapshot
     struct mem_map *map;
     /* thread identifiers */
     int *tids;
+    /* thread states */
+    char *states;
     /* number of threads */
     int num_threads;
     /* current thread (used when unwinding stack) */

--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -37,6 +37,7 @@ size_t stack_size = 0;
 int opt_proc_mem = 0;
 int opt_ptrace = 0;
 int opt_show_rsp = 0;
+int opt_show_state = 0;
 int opt_verbose = 0;
 int stop_timeout = 1000000;
 int opt_ignore_deleted = 0;
@@ -56,6 +57,7 @@ static int usage(const char *name)
 "          --ptrace              use libunwind-ptrace interface (slower)\n"
 #endif
 "          --show-rsp            show %%rsp in second column\n"
+"          --show-state          show thread state before freeze\n"
 "          --stack-size <size>   maximum stack size to copy (default is current\n"
 "                                RLIMIT_STACK)\n"
 "          --stop-timeout        timeout for waiting the process to freeze, in\n"
@@ -149,6 +151,7 @@ static void parse_options(int argc, char **argv)
             { "stop-timeout", 1, NULL, 0},
             { "ignore-deleted", 0, NULL, 0},
             { "use-waitpid-timeout", 0, NULL, 0 },
+            { "show-state", 0, NULL, 0 },
             { 0, 0, 0, 0 }
         };
 
@@ -210,6 +213,10 @@ static void parse_options(int argc, char **argv)
 
             case 8:
                 opt_use_waitpid_timeout = 1;
+                break;
+
+            case 9:
+                opt_show_state = 1;
                 break;
 
             default:

--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -57,7 +57,7 @@ static int usage(const char *name)
 "          --ptrace              use libunwind-ptrace interface (slower)\n"
 #endif
 "          --show-rsp            show %%rsp in second column\n"
-"          --show-state          show thread state before freeze\n"
+"          --show-state          show thread states\n"
 "          --stack-size <size>   maximum stack size to copy (default is current\n"
 "                                RLIMIT_STACK)\n"
 "          --stop-timeout        timeout for waiting the process to freeze, in\n"


### PR DESCRIPTION
This introduces option --show-state to add thread state in thread heading. The thread state is captured right before freezing the process. There is a possibility that it is changed in the meantime.