### PR TITLE
snapshot: define PTRACE_GETREGSET if unavailable

### DIFF
--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -18,6 +18,10 @@
 #include <unistd.h>
 #include <elf.h>
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+
 extern size_t stack_size;
 extern int opt_verbose;
 


### PR DESCRIPTION
In the same way as we do for `SYS_process_vm_readv` (file `proc.c`). It's often supported by kernel but not defined in older kernel headers / glibc.