### PR TITLE
tbstack: fix format specifier warnings

### DIFF
--- a/src/proc.c
+++ b/src/proc.c
@@ -131,7 +131,7 @@ struct mem_map *create_maps(int pid)
         if (next != NULL)
             *next = '\0';
 
-        scan = sscanf(str, "%lx-%lx %c%c%c%c %lx %x:%x %d %[^\t\n]",
+        scan = sscanf(str, "%zx-%zx %c%c%c%c %zx %x:%x %d %[^\t\n]",
                 &addr_start, &addr_end,
                 &r, &w, &x, &p,
                 &offset,
@@ -432,8 +432,8 @@ static int copy_memory_process_vm_readv(int pid,
 
         if (seg_count < 0) {
             fprintf(stderr, "unknown number of bytes returned by "
-                    "process_vm_readv: bytes_read=%ld "
-                    "bytes_total=%ld seg_count=%d\n",
+                    "process_vm_readv: bytes_read=%zd "
+                    "bytes_total=%zd seg_count=%d\n",
                     bytes_read, bytes_total, seg_count);
             goto process_vm_readv_end;
         }

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -163,9 +163,9 @@ struct snapshot *get_snapshot(int pid, int *tids, int *index, int nr_tids)
     if (opt_verbose) {
         for (i = 0; i < n_frames; ++i) {
             struct mem_data_chunk *chunk = stacks_cover[i];
-            printf("chunk #%d: 0x%lx-0x%lx length: %ldK\n",
-                    i, (size_t)chunk->start,
-                    (size_t)chunk->start + chunk->length,
+            printf("chunk #%d: %p-%p length: %zdK\n",
+                    i, chunk->start,
+                    chunk->start + chunk->length,
                     chunk->length >> 10);
         }
     }

--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -317,7 +317,7 @@ static void summary()
     printf("-----------------------  summary  --------------------------\n"
            " time the process was frozen: %ldms %ldus\n"
            " sleep count: %d\n"
-           " total bytes copied: 0x%lx (%ldK)\n",
+           " total bytes copied: 0x%zx (%zdK)\n",
            tm/1000, tm%1000, sleep_count, total_length, total_length>>10);
 }
 


### PR DESCRIPTION
Most of these occur when building for 32-bit. e.g.

warning: format ‘%ld’ expects argument of type ‘long int’, but argument
3 has type ‘ssize_t {aka int}’ [-Wformat=]

In general, use the 'z' modifier for size_t and %p conversion for
pointers.