### PR TITLE
tbstack: Fix indexing out of bounds error on aarch64 for SP_REG()

### DIFF
--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -21,7 +21,7 @@ typedef struct user_regs_struct regs_t;
 #if defined(__arm__)
 #define SP_REG(regs) ((regs)->uregs[13])
 #elif defined(__aarch64__)
-#define SP_REG(r) ((r)->regs[31])
+#define SP_REG(r) ((r)->sp)
 #elif defined(__i386)
 #define SP_REG(regs) ((regs)->esp)
 #elif defined(__x86_64)


### PR DESCRIPTION
SP_REG() is r->sp and not r->regs[31].

From /usr/include/sys/user.h: (aarch64)
struct user_regs_struct
{
  unsigned long long regs[31];
  unsigned long long sp;
  unsigned long long pc;
  unsigned long long pstate;
};

Fixes a compile error with -Werror=array-bounds.