### PR TITLE
Thread states

### DIFF
--- a/README
+++ b/README
@@ -50,6 +50,7 @@ options:  --help                show this
                                 is process_vm_readv
           --ptrace              use libunwind-ptrace interface (slower)
           --show-rsp            show %rsp in second column
+          --show-state          show thread states
           --stack-size <size>   maximum stack size to copy (default is current
                                 RLIMIT_STACK)
           --stop-timeout        timeout for waiting the process to freeze, in

--- a/src/proc.c
+++ b/src/proc.c
@@ -51,12 +51,12 @@ extern int opt_proc_mem;
 extern int opt_use_waitpid_timeout;
 extern int opt_verbose;
 
-int proc_stopped(int pid)
+int proc_state(int pid)
 {
     FILE *f;
     char buf[128];
     char c;
-    int rc = -1;
+    int res = -1;
 
     sprintf(buf, "/proc/%d/status", pid);
     if ((f = fopen(buf, "r")) == NULL) {
@@ -66,13 +66,22 @@ int proc_stopped(int pid)
 
     while (fgets(buf, sizeof(buf), f)) {
         if (sscanf(buf, "State:\t%c", &c) == 1) {
-            rc = (c == 't' || c == 'T');
+            res = c;
             break;
         }
     }
 
     fclose(f);
-    return rc;
+    return res;
+}
+
+static int proc_stopped(int pid)
+{
+    int c = proc_state(pid);
+    if (c == -1)
+        return -1;
+
+    return (c == 't' || c == 'T');
 }
 
 struct mem_map *create_maps(int pid)
@@ -229,6 +238,25 @@ int get_threads(int pid, int **tids)
     }
 
     return n;
+}
+
+char *get_thread_states(const int *tids, int n)
+{
+    int i;
+    char *res = calloc(1, n);
+
+    for (i = 0; i < n; ++i) {
+        int state = proc_state(tids[i]);
+        if (state < 0) {
+            fprintf(stderr, "warning: could not get state of thread %d\n",
+                    tids[i]);
+            res[i] = '?';
+            continue;
+        }
+        res[i] = state;
+    }
+
+    return res;
 }
 
 int adjust_threads(int *tids, int nr_tids, int *user_tids,

--- a/src/proc.h
+++ b/src/proc.h
@@ -12,9 +12,9 @@ struct mem_data_chunk;
 struct mem_map;
 
 /*
- * check if the process is in state stopped (S)
+ * returns process state (R, S, D, T, ...) or -1 on error
  */
-int proc_stopped(int pid);
+int proc_state(int pid);
 
 /*
  * parse /proc/<pid>/maps file and create mem_map structure
@@ -31,6 +31,12 @@ int print_proc_maps(int pid);
  * get thread identifiers of the process
  */
 int get_threads(int pid, int **tids);
+
+/*
+ * returns a pointer to dynamically allocated array of characters representing
+ * thread states as found in /proc/<pid>/status
+ */
+char *get_thread_states(const int *tids, int n);
 
 /*
  * translate thread numbers to system lwp ids

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -19,6 +19,7 @@
 #include <elf.h>
 
 extern size_t stack_size;
+extern int opt_show_state;
 extern int opt_verbose;
 
 void snapshot_destroy(struct snapshot *snap)
@@ -31,6 +32,7 @@ void snapshot_destroy(struct snapshot *snap)
 
     free(snap->regs);
     free(snap->tids);
+    free(snap->states);
     free(snap);
 }
 
@@ -86,6 +88,9 @@ struct snapshot *get_snapshot(int pid, int *tids, int *index, int nr_tids)
         perror("malloc");
         goto get_snapshot_fail;
     }
+
+    if (opt_show_state)
+        res->states = get_thread_states(res->tids, res->num_threads);
 
     /* FREEZE PROCESS */
     if (attach_process(pid) < 0)

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -36,6 +36,8 @@ struct snapshot
     struct mem_map *map;
     /* thread identifiers */
     int *tids;
+    /* thread states */
+    char *states;
     /* number of threads */
     int num_threads;
     /* current thread (used when unwinding stack) */

--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -37,6 +37,7 @@ size_t stack_size = 0;
 int opt_proc_mem = 0;
 int opt_ptrace = 0;
 int opt_show_rsp = 0;
+int opt_show_state = 0;
 int opt_verbose = 0;
 int stop_timeout = 1000000;
 int opt_ignore_deleted = 0;
@@ -56,6 +57,7 @@ static int usage(const char *name)
 "          --ptrace              use libunwind-ptrace interface (slower)\n"
 #endif
 "          --show-rsp            show %%rsp in second column\n"
+"          --show-state          show thread states\n"
 "          --stack-size <size>   maximum stack size to copy (default is current\n"
 "                                RLIMIT_STACK)\n"
 "          --stop-timeout        timeout for waiting the process to freeze, in\n"
@@ -149,6 +151,7 @@ static void parse_options(int argc, char **argv)
             { "stop-timeout", 1, NULL, 0},
             { "ignore-deleted", 0, NULL, 0},
             { "use-waitpid-timeout", 0, NULL, 0 },
+            { "show-state", 0, NULL, 0 },
             { 0, 0, 0, 0 }
         };
 
@@ -210,6 +213,10 @@ static void parse_options(int argc, char **argv)
 
             case 8:
                 opt_use_waitpid_timeout = 1;
+                break;
+
+            case 9:
+                opt_show_state = 1;
                 break;
 
             default:


### PR DESCRIPTION
This introduces option `--show-state` to add thread state in thread heading. The thread state is captured right before freezing the process. There is a possibility that it is changed in the meantime.