### PR TITLE
Fix x86 issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,8 @@ AM_SILENT_RULES([yes])
 AC_GNU_SOURCE
 AC_PROG_CC
 
+AC_SYS_LARGEFILE
+
 AC_SEARCH_LIBS([elf_begin], [elf], [], [
 	AC_MSG_ERROR([unable to find the elf_begin() in libelf])
 ])

--- a/src/proc.c
+++ b/src/proc.c
@@ -486,7 +486,7 @@ static int copy_memory_proc_mem(int pid, struct mem_data_chunk **frames,
             ssize_t rd = pread(fd, to, count, from);
 
             if (rd == -1) {
-                fprintf(stderr, "pread() at %s:0x%lx (#%d) failed: %s [%d]\n",
+                fprintf(stderr, "pread() at %s:0x%jx (#%d) failed: %s [%d]\n",
                         fname, from, i, strerror(errno), errno);
                 goto proc_mem_end;
             }

--- a/src/proc.c
+++ b/src/proc.c
@@ -29,7 +29,13 @@
 #include <unistd.h>
 
 #ifndef SYS_process_vm_readv
+#if defined(__i386)
+#define SYS_process_vm_readv 365
+#elif defined(__x86_64)
 #define SYS_process_vm_readv 310
+#else
+#error SYS_process_vm_readv is undefined
+#endif
 #endif
 
 #define SLEEP_WAIT 500


### PR DESCRIPTION
This is to fix problems described in https://github.com/tbricks/tbstack/issues/17.
1) Added definition of `SYS_process_vm_readv` for x86 in the same way as done for x86_64;
2) Added `AC_SYS_LARGEFILE` macro to `configure.ac`.

If `SYS_process_vm_readv` is still undefined, and architecture is neither x86 nor x86_64, explicit compilation failure occurs. I didn't add any options to disable `process_vm_readv` for now and I think it could be further improvement. Though it wasn't requested so far.