### PR TITLE
Use basename() only for mmap regions

### DIFF
--- a/src/mem_map.c
+++ b/src/mem_map.c
@@ -171,7 +171,7 @@ static struct mem_data_chunk *mem_region_alloc_chunk(struct mem_region *region,
     return chunk;
 }
 
-static const char *str_mem_region_type(int type)
+const char *str_mem_region_type(int type)
 {
     switch (type)
     {

--- a/src/mem_map.h
+++ b/src/mem_map.h
@@ -79,6 +79,9 @@ struct mem_map
 /*
  * mem region
  */
+
+const char *str_mem_region_type(int type);
+
 void mem_region_init(struct mem_region *region);
 
 /*

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -809,10 +809,15 @@ static int get_proc_name(unw_addr_space_t as, unw_word_t addr, char *bufp,
 
     if (name == NULL) {
         /*
-         * if name cannot be resolved, print binary file name
+         * if name cannot be resolved, print binary file name or region type
          */
-        const char *base = basename(region->path);
-        snprintf(bufp, buf_len, "?? (%s)", base);
+        if (region->type == MEM_REGION_TYPE_MMAP) {
+            const char *base = basename(region->path);
+            snprintf(bufp, buf_len, "?? (%s)", base);
+        } else {
+            snprintf(bufp, buf_len, "?? [%s]",
+                    str_mem_region_type(region->type));
+        }
         *offp = 0;
         return 0;
     }


### PR DESCRIPTION
When a function name cannot be resolved, we print `'?? (<basename>)'`
which obviously makes sense only for binaries and shared objects. In case of
unresolved name in other regions (vdso), region type in square brackets
will be printed.