### PR TITLE
 Ability to filter threads by state

### DIFF
--- a/README
+++ b/README
@@ -42,6 +42,7 @@ USAGE
 
 usage:    tbstack <pid>
           tbstack <pid>/<tid1>,...,<tidn>
+          tbstack <pid>/RS
 
 options:  --help                show this
           --ignore-deleted      try to open shared objects marked as deleted

--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -24,6 +24,7 @@ extern unw_accessors_t snapshot_addr_space_accessors;
 extern int opt_show_rsp;
 extern int opt_show_state;
 extern int opt_verbose;
+extern char *opt_thread_states;
 
 static int backtrace_thread(unw_accessors_t *accessors, void *arg)
 {
@@ -156,8 +157,11 @@ int backtrace_ptrace(int pid, int *tids, int *index, int nr_tids)
         threads = tids;
     }
 
-    if (opt_show_state)
+    if (opt_show_state || opt_thread_states)
         states = get_thread_states(threads, count);
+
+    if (opt_thread_states)
+        count = filter_threads(threads, index, states, count, opt_thread_states);
 
     if (attach_process(pid) < 0)
         return -1;

--- a/src/proc.c
+++ b/src/proc.c
@@ -290,6 +290,27 @@ int adjust_threads(int *tids, int nr_tids, int *user_tids,
     return 0;
 }
 
+int filter_threads(int tids[], int index[], char states[], int nr_tids,
+        const char *user_states)
+{
+    int i, j = 0;
+    int nr_prev = nr_tids;
+    for (i = 0; i < nr_prev; ++i) {
+        if (strchr(user_states, states[i]) != NULL) {
+            if (i != j) {
+                tids[j] = tids[i];
+                states[j] = states[i];
+                if (index != NULL)
+                    index[j] = index[i];
+            }
+            ++j;
+        } else {
+            --nr_tids;
+        }
+    }
+    return nr_tids;
+}
+
 int attach_process(int pid)
 {
     int status = 0;

--- a/src/proc.h
+++ b/src/proc.h
@@ -45,6 +45,12 @@ int adjust_threads(int *tids, int nr_tids, int *user_tids,
         int *index, int nr_user);
 
 /*
+ * filter threads by state. returns new number of threads
+ */
+int filter_threads(int tids[], int index[], char states[], int nr_tids,
+        const char *user_states);
+
+/*
  * attach to the process, wait until it's stopped,
  * send SIGSTOP to make all threads frozen
  */

--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -42,12 +42,14 @@ int opt_verbose = 0;
 int stop_timeout = 1000000;
 int opt_ignore_deleted = 0;
 int opt_use_waitpid_timeout = 0;
+char *opt_thread_states = NULL;
 
 static int usage(const char *name)
 {
     fprintf(stderr,
 "usage:    %s <pid>\n"
-"          %s <pid>/<tid1>,...,<tidn>\n\n"
+"          %s <pid>/<tid1>,...,<tidn>\n"
+"          %s <pid>/RS\n\n"
 "options:  --help                show this\n"
 "          --ignore-deleted      try to open shared objects marked as deleted\n"
 "          --use-waitpid-timeout set alarm to interrupt waitpid\n"
@@ -63,7 +65,7 @@ static int usage(const char *name)
 "          --stop-timeout        timeout for waiting the process to freeze, in\n"
 "                                milliseconds. default value is %d\n"
 "          --verbose             verbose error messages\n",
-        name, name, stop_timeout/1000);
+        name, name, name, stop_timeout/1000);
     return 2;
 }
 
@@ -90,6 +92,21 @@ static void parse_pid_arg(const char *prog, char *arg)
     if (tstr != NULL) {
         char c, prev = '\0';
         int i = 0, j;
+        int is_state_list = 1;
+
+        /* check if state list is provided */
+        pos = tstr;
+        while ((c = *pos++)) {
+            if (!isalpha(c)) {
+                is_state_list = 0;
+                break;
+            }
+        }
+
+        if (is_state_list) {
+            opt_thread_states = strdup(tstr);
+            return;
+        }
 
         pos = tstr;
         if (*pos == ',')


### PR DESCRIPTION
The new syntax is tbstack <pid>/<state list>. For example,
```$ tbstack 1234/R```
Will show only threads in state Running.