### PR TITLE
DWARF unwind support fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,9 +30,11 @@ AS_IF(test "$use_ptrace" == yes,
 	 AC_DEFINE([NO_LIBUNWIND_PTRACE], [1], [Don't use libunwind's ptrace support])]
 )
 
-echo -n "Checking for dwarf unwind support... "
-SAVED_LDFLAGS="$LDFLAGS"
-LDFLAGS=$LIBUNWIND_LIBS
+AC_MSG_CHECKING(for dwarf unwind support)
+SAVED_LIBS="$LIBS"
+LIBS="$LIBUNWIND_LIBS"
+SAVED_CFLAGS="$CFLAGS"
+CFLAGS="$LIBUNWIND_CFLAGS"
 AC_LINK_IFELSE([
 	AC_LANG_SOURCE([[
 #include <dwarf.h>
@@ -52,12 +54,13 @@ int main(void)
 	return 0;
 }
 ]])], [dwarf_debug_frame=yes])
-LDFLAGS="$SAVED_LDFLAGS"
+LIBS="$SAVED_LIBS"
+CFLAGS="$SAVED_CFLAGS"
 
 if test "$dwarf_debug_frame" != yes; then
-	echo "no"
+	AC_MSG_RESULT(no)
 else
-	echo "yes"
+	AC_MSG_RESULT(yes)
 	AC_DEFINE([HAVE_DWARF],[1],[DWARF debug_frame support in libunwind])
 fi
 

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -41,8 +41,8 @@ extern int search_unwind_table(unw_addr_space_t as, unw_word_t ip,
 #ifdef HAVE_DWARF
 #define dwarf_find_debug_frame UNW_OBJ(dwarf_find_debug_frame)
 
-extern int
-UNW_OBJ(dwarf_find_debug_frame)(int found, unw_dyn_info_t *di_debug,
+extern int dwarf_find_debug_frame(int found,
+                                unw_dyn_info_t *di_debug,
                                 unw_word_t ip,
                                 unw_word_t segbase,
                                 const char *obj_name, unw_word_t start,
@@ -567,7 +567,8 @@ static int find_proc_info(unw_addr_space_t as, unw_word_t ip,
     }
 
     if (dwarf_find_debug_frame(0, &di, ip, base, region->path,
-                region->start, region->start + region->length))
+                (unw_word_t) region->start,
+                (unw_word_t) region->start + region->length))
             return search_unwind_table(as, ip, &di, pip, need_unwind_info, arg);
 #endif
 


### PR DESCRIPTION
1) check for dwarf unwind support in `configure.ac`
   - `LIBS` variable should be used instead of `LDFLAGS`
   - `CFLAGS` should be set
2) warnings: implicit function declaration, pointer to
   integer conversion.