### PR TITLE
Exit on invalid command line option

### DIFF
--- a/src/tbstack.c
+++ b/src/tbstack.c
@@ -242,6 +242,7 @@ static void parse_options(int argc, char **argv)
             break;
 
         case '?':
+            exit(usage(argv[0]));
             break;
 
         default:


### PR DESCRIPTION
tbstack should exit with status 2 if a command line option is invalid