### PR TITLE
unwind: Fix another out of bounds indexing issue on aarch64

### DIFF
--- a/src/unwind.c
+++ b/src/unwind.c
@@ -623,14 +623,23 @@ static int access_reg(unw_addr_space_t as, unw_regnum_t reg,
 
     switch (reg) {
 #if defined(UNW_TARGET_AARCH64)
-    case UNW_AARCH64_X0 ... UNW_AARCH64_PC:
+    case UNW_AARCH64_X0 ... UNW_AARCH64_X30:
         /*
          * Currently this enum directly maps to the index so this is a no-op.
          * Assert just in case.
          */
         reg -= UNW_AARCH64_X0;
-        assert(reg>= 0 && reg <= 32);
+        assert(reg>= 0 && reg <= 30);
         *val = snap->regs[snap->cur_thr].regs[reg];
+        break;
+    case UNW_AARCH64_SP:
+        *val = snap->regs[snap->cur_thr].sp;
+        break;
+    case UNW_AARCH64_PC:
+        *val = snap->regs[snap->cur_thr].pc;
+        break;
+    case UNW_AARCH64_PSTATE:
+        *val = snap->regs[snap->cur_thr].pstate;
         break;
 #elif defined(UNW_TARGET_ARM)
     case UNW_ARM_R0 ... UNW_ARM_R15:


### PR DESCRIPTION
When accessing registers via libunwind on aarch64, such as UNW_AARCH64_SP, we
were incorrectly assuming the the stack pointer was part of the regs array of
the user_regs_struct.

When compiling with '-fsanitize=bounds -fno-sanitize-recover
-fsanitize-undefined-trap-on-error', tbstack was failing with a SIGTRAP error
at runtime due to this array indexing error.