### PR TITLE
Add permision to use the software

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
 Copyright (c) 2014, Tbricks AB
 All rights reserved.
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer. 
 2. Redistributions in binary form must reproduce the above copyright notice,


### PR DESCRIPTION
I believe that tbstack was meant to be distributed under [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) license. The license contains the copyright holder and the conditions of the license, but seems to be missing the permissions.